### PR TITLE
fix utf8

### DIFF
--- a/src/ast/ann_func.rs
+++ b/src/ast/ann_func.rs
@@ -1,6 +1,5 @@
+use crate::WparseError;
 use crate::ast::AnnFun;
-use crate::{WparseError, WparseReason};
-use orion_error::conversion::ToStructError;
 use smol_str::SmolStr;
 use std::collections::BTreeMap;
 use wp_connector_api::SourceEvent;
@@ -45,26 +44,18 @@ impl AnnotationFunc for RawCopy {
             RawData::String(raw) => {
                 data.append(DataField::from_chars(self.raw_key.clone(), raw.clone()));
             }
-            RawData::Bytes(raw) => match std::str::from_utf8(raw) {
-                Ok(str) => {
-                    data.append(DataField::from_chars(self.raw_key.clone(), str.to_string()));
-                }
-                Err(e) => {
-                    return Err(WparseReason::data_error()
-                        .to_err()
-                        .with_detail(format!("[u8] to string error :{}", e)));
-                }
-            },
-            RawData::ArcBytes(raw) => match std::str::from_utf8(raw) {
-                Ok(str) => {
-                    data.append(DataField::from_chars(self.raw_key.clone(), str.to_string()));
-                }
-                Err(e) => {
-                    return Err(WparseReason::data_error()
-                        .to_err()
-                        .with_detail(format!("ArcBytes to string error :{}", e)));
-                }
-            },
+            RawData::Bytes(raw) => {
+                data.append(DataField::from_chars(
+                    self.raw_key.clone(),
+                    String::from_utf8_lossy(raw).into_owned(),
+                ));
+            }
+            RawData::ArcBytes(raw) => {
+                data.append(DataField::from_chars(
+                    self.raw_key.clone(),
+                    String::from_utf8_lossy(raw).into_owned(),
+                ));
+            }
         }
         Ok(())
     }
@@ -115,8 +106,10 @@ impl AnnotationType {
 mod tests {
     use super::*;
     use crate::pkg::DEFAULT_KEY;
+    use bytes::Bytes;
     use orion_error::dev::testing::TestAssert;
     use std::collections::BTreeMap;
+    use std::sync::Arc;
     use wp_connector_api::{SourceEvent, Tags};
     use wp_model_core::model::DataRecord;
     use wp_model_core::raw::RawData;
@@ -157,5 +150,50 @@ mod tests {
         tag.first().unwrap().proc(&src, &mut data).unwrap();
         let expected = DataField::from_chars("raw", "test");
         assert_eq!(data.field("raw").map(|s| s.as_field()), Some(&expected));
+    }
+
+    #[test]
+    fn test_copy_fun_handles_invalid_utf8_bytes() {
+        let tag = copy_raw_tag("raw");
+        let raw = Bytes::from_static(b"hello \xff\xfe\xc0\xaf");
+        let expected_raw = String::from_utf8_lossy(&raw).into_owned();
+        let mut data = DataRecord::test_value();
+        let src = SourceEvent::new(
+            1,
+            DEFAULT_KEY.to_string(),
+            RawData::Bytes(raw),
+            Tags::new().into(),
+        );
+
+        tag.first().unwrap().proc(&src, &mut data).unwrap();
+
+        let expected = DataField::from_chars("raw", expected_raw);
+        assert_eq!(data.field("raw").map(|s| s.as_field()), Some(&expected));
+    }
+
+    #[test]
+    fn test_copy_fun_handles_invalid_utf8_arc_bytes() {
+        let tag = copy_raw_tag("raw");
+        let raw = Arc::new(b"hello \xff\xfe\xc0\xaf".to_vec());
+        let expected_raw = String::from_utf8_lossy(raw.as_slice()).into_owned();
+        let mut data = DataRecord::test_value();
+        let src = SourceEvent::new(
+            1,
+            DEFAULT_KEY.to_string(),
+            RawData::ArcBytes(raw),
+            Tags::new().into(),
+        );
+
+        tag.first().unwrap().proc(&src, &mut data).unwrap();
+
+        let expected = DataField::from_chars("raw", expected_raw);
+        assert_eq!(data.field("raw").map(|s| s.as_field()), Some(&expected));
+    }
+
+    fn copy_raw_tag(raw_key: &str) -> Vec<AnnotationType> {
+        AnnotationType::convert(&Some(AnnFun {
+            tags: Default::default(),
+            copy_raw: Some(("name".into(), raw_key.into())),
+        }))
     }
 }


### PR DESCRIPTION
# Fix copy_raw handling for invalid UTF-8 payloads

## Summary

修复 `copy_raw` 在原始日志包含非法 UTF-8 字节时导致解析结果进入 miss 的问题。

本次修复位置在 `wp-lang`：

```text
/Users/zwk/src_code/wp-labs/wp-lang/src/ast/ann_func.rs
```

修复后，`copy_raw` 对 bytes payload 使用 lossy UTF-8 方式生成 `raw_msg`，非法字节会以替代字符展示，不再导致整条日志解析失败。

## Problem

当 WPL 规则使用 `#[copy_raw(name:"raw_msg")]` 时，规则匹配成功后会把原始日志写入 `raw_msg` 字段。

在原始日志是 bytes payload 且包含非法 UTF-8 字节时，`copy_raw` 原先会使用严格 UTF-8 转换处理原始 bytes。转换失败后，annotation 阶段返回错误，导致已经匹配成功的日志最终进入 miss。

实际用户现象：

```text
src_key: tcp_1  | data:
180.57.30.148 - - [21/Jan/2025:01:40:02 +0800] "GET /nginx-logo.png HTTP/1.1" 500 368 "http://207.131.38.110/�����" ...
target wpl: /example/nginx_raw
Error: data error
```

JSON 场景同样会出现：

```text
{"sip":"10.0.220.200","dip":"10.0.220.201","�����":"2","log_type":"pg������"}
target wpl: /example/nginx_json
Error: data error
```

## Changes

### `src/ast/ann_func.rs`

调整 `RawCopy::proc` 中对 bytes payload 的处理。

修改前：

```rust
RawData::Bytes(raw) => match std::str::from_utf8(raw) {
    Ok(str) => {
        data.append(DataField::from_chars(self.raw_key.clone(), str.to_string()));
    }
    Err(e) => {
        return Err(...);
    }
}
```

修改后：

```rust
RawData::Bytes(raw) => {
    data.append(DataField::from_chars(
        self.raw_key.clone(),
        String::from_utf8_lossy(raw).into_owned(),
    ));
}
```

同时对 `RawData::ArcBytes` 做同样处理。

这样 `RawData::String`、`RawData::Bytes`、`RawData::ArcBytes` 三类 payload 在 `copy_raw` 下都可以稳定写入 `raw_msg`。

## Tests

新增测试：

```rust
test_copy_fun_handles_invalid_utf8_bytes
test_copy_fun_handles_invalid_utf8_arc_bytes
```

覆盖场景：

- `RawData::Bytes` 中包含非法 UTF-8 字节。
- `RawData::ArcBytes` 中包含非法 UTF-8 字节。
- `copy_raw` 不返回错误。
- `raw_msg` 字段内容等于 lossy UTF-8 后的结果。

保留并通过既有测试：

```rust
test_copy_fun
test_tag_fun
```

## Verification

已在 `wp-lang` 仓库执行：

```bash
cargo fmt --all
cargo test ast::ann_func::tests::test_copy_fun
cargo test
```

验证结果：

```text
cargo test ast::ann_func::tests::test_copy_fun
  3 passed; 0 failed

cargo test
  418 passed; 0 failed
```

## User Impact

修复前：

```text
日志主规则匹配成功
copy_raw 写入 raw_msg 时失败
整条日志进入 miss
```

修复后：

```text
日志主规则匹配成功
copy_raw 正常写入 raw_msg
日志正常输出到业务 sink
```

非法字节在 `raw_msg` 中会显示为替代字符 `�`。

## Risk

风险较低。

该改动只影响 `copy_raw` 对 bytes payload 的处理方式。

行为变化：

- 之前非法 UTF-8 bytes 会导致 `copy_raw` 返回错误。
- 现在非法 UTF-8 bytes 会被替换为 `�` 并写入 `raw_msg`。

如果未来需要保留完全原始的二进制内容，应新增专门的 bytes/base64/hex 类型或编码策略，而不应继续放入 `chars` 类型字段。

## Related Issue

```text
tmp/copy-raw-invalid-utf8-issue.md
```
